### PR TITLE
feat(#17): Dashboard UX improvements — icons, Gravatar, move-to-top, drag indicator, logout fix

### DIFF
--- a/backend/PriorityHub.Ui/Components/NavBar.razor
+++ b/backend/PriorityHub.Ui/Components/NavBar.razor
@@ -20,6 +20,12 @@
                         var provider = context.User.FindFirst("provider")?.Value ?? "";
                         var displayName = name ?? email ?? "Signed in";
                         var displayEmail = email ?? $"{WorkItemRanker.FormatProviderName(provider)} account";
+
+                        if (string.IsNullOrWhiteSpace(picture) && !string.IsNullOrWhiteSpace(email))
+                        {
+                            var hash = GravatarHash(email);
+                            picture = $"https://www.gravatar.com/avatar/{hash}?s=68&d=mp";
+                        }
                     }
                     @if (!string.IsNullOrWhiteSpace(picture))
                     {
@@ -37,8 +43,8 @@
                     </div>
                     <form method="post" action="/api/auth/logout">
                         <AntiforgeryToken />
-                        <button class="signout-button" type="submit">
-                            Sign out
+                        <button class="signout-button" type="submit" title="Sign out">
+                            <svg class="action-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
                         </button>
                     </form>
                 </div>
@@ -48,4 +54,10 @@
 </header>
 
 @code {
+    private static string GravatarHash(string email)
+    {
+        var trimmed = email.Trim().ToLowerInvariant();
+        var bytes = System.Security.Cryptography.MD5.HashData(System.Text.Encoding.ASCII.GetBytes(trimmed));
+        return Convert.ToHexStringLower(bytes);
+    }
 }

--- a/backend/PriorityHub.Ui/Components/Pages/DashboardPage.razor
+++ b/backend/PriorityHub.Ui/Components/Pages/DashboardPage.razor
@@ -247,12 +247,17 @@
 
                     @foreach (var item in FilteredItems)
                     {
-                        var cardClass = "work-item-card" + (item.Item.IsNew ? " is-new-item" : "") + (_draggedItemId == item.Item.Id ? " is-dragging" : "");
+                        var cardClass = "work-item-card"
+                            + (item.Item.IsNew ? " is-new-item" : "")
+                            + (_draggedItemId == item.Item.Id ? " is-dragging" : "")
+                            + (_dragOverItemId == item.Item.Id && _draggedItemId != item.Item.Id ? " drag-over" : "");
                         <article class="@cardClass"
                                  draggable="true"
                                  @ondragstart="() => _draggedItemId = item.Item.Id"
-                                 @ondragend="() => _draggedItemId = null"
+                                 @ondragend="OnDragEnd"
+                                 @ondragenter="() => _dragOverItemId = item.Item.Id"
                                  @ondragover:preventDefault
+                                 @ondragleave="() => { if (_dragOverItemId == item.Item.Id) _dragOverItemId = null; }"
                                  @ondrop="() => HandleDropItem(item.Item.Id)">
                             <div class="work-item-heading">
                                 <div class="work-item-title">
@@ -262,15 +267,25 @@
                                         <span class="new-pill">New item</span>
                                     }
                                 </div>
-                                @if (!string.IsNullOrWhiteSpace(item.Item.SourceUrl))
-                                {
-                                    <a href="@item.Item.SourceUrl"
-                                       target="_blank"
-                                       rel="noopener noreferrer"
-                                       class="item-source-link">
-                                        Open in source
-                                    </a>
-                                }
+                                <div class="item-actions">
+                                    <button type="button"
+                                            class="item-action-button"
+                                            title="Move to top"
+                                            @onclick="() => MoveToTop(item.Item.Id)"
+                                            @onclick:stopPropagation>
+                                        <svg class="action-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/><line x1="5" y1="3" x2="19" y2="3"/></svg>
+                                    </button>
+                                    @if (!string.IsNullOrWhiteSpace(item.Item.SourceUrl))
+                                    {
+                                        <a href="@item.Item.SourceUrl"
+                                           target="_blank"
+                                           rel="noopener noreferrer"
+                                           class="item-action-button"
+                                           title="Open in source">
+                                            <svg class="action-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
+                                        </a>
+                                    }
+                                </div>
                             </div>
 
                             <div class="tag-row">
@@ -317,6 +332,7 @@
     private List<string> _selectedTags = [];
     private string _search = "";
     private string? _draggedItemId;
+    private string? _dragOverItemId;
     private bool _savingOrder;
     private bool _showConnectors;
     private CancellationTokenSource? _cts;
@@ -408,16 +424,44 @@
         if (_draggedItemId is null || _draggedItemId == targetId)
         {
             _draggedItemId = null;
+            _dragOverItemId = null;
             return;
         }
 
         var currentVisibleIds = _rankedItems.Select(i => i.Item.Id).ToList();
         var nextOrderedIds = ReorderVisibleItems(currentVisibleIds, _orderedItemIds, _draggedItemId, targetId);
+        _draggedItemId = null;
+        _dragOverItemId = null;
         _orderedItemIds = nextOrderedIds;
         _rankedItems = Ranker.Rank(_dashboard.WorkItems, _dashboard.BoardConnections, _orderedItemIds);
+        StateHasChanged();
+
+        await SaveOrderAsync(nextOrderedIds);
+    }
+
+    private async Task MoveToTop(string itemId)
+    {
+        var nextOrderedIds = new List<string>(_orderedItemIds);
+        nextOrderedIds.Remove(itemId);
+        nextOrderedIds.Insert(0, itemId);
+
+        _orderedItemIds = nextOrderedIds;
+        _rankedItems = Ranker.Rank(_dashboard.WorkItems, _dashboard.BoardConnections, _orderedItemIds);
+        StateHasChanged();
+
+        await SaveOrderAsync(nextOrderedIds);
+    }
+
+    private void OnDragEnd()
+    {
+        _draggedItemId = null;
+        _dragOverItemId = null;
+    }
+
+    private async Task SaveOrderAsync(List<string> newOrder)
+    {
         _savingOrder = true;
         _statusMessage = null;
-        _draggedItemId = null;
         StateHasChanged();
 
         try
@@ -429,7 +473,7 @@
             var config = await ConfigStore.LoadAsync(userId, CancellationToken.None);
             config.Preferences = new UserPreferences
             {
-                OrderedItemIds = nextOrderedIds
+                OrderedItemIds = newOrder
                     .Where(id => !string.IsNullOrWhiteSpace(id))
                     .Distinct(StringComparer.OrdinalIgnoreCase)
                     .ToList()

--- a/backend/PriorityHub.Ui/Program.cs
+++ b/backend/PriorityHub.Ui/Program.cs
@@ -246,7 +246,7 @@ app.MapGet("/api/auth/login/github", (IConfiguration configuration) =>
 app.MapPost("/api/auth/logout", async (HttpContext httpContext) =>
 {
     await httpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
-    return Results.Ok(new { ok = true });
+    return Results.Redirect("/login");
 }).RequireAuthorization();
 
 app.MapGet("/api/config", async (HttpContext httpContext, LocalConfigStore configStore, CancellationToken cancellationToken) =>

--- a/backend/PriorityHub.Ui/wwwroot/app.css
+++ b/backend/PriorityHub.Ui/wwwroot/app.css
@@ -192,12 +192,24 @@ textarea {
 }
 
 .signout-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   border: 0;
   border-radius: 999px;
-  padding: 11px 16px;
-  background: rgba(14, 45, 73, 0.1);
-  color: var(--dti-black);
+  padding: 8px;
+  background: rgba(248, 250, 252, 0.12);
+  color: #F8FAFC;
   cursor: pointer;
+}
+
+.signout-button:hover {
+  background: rgba(248, 250, 252, 0.22);
+}
+
+.signout-button .action-icon {
+  width: 18px;
+  height: 18px;
 }
 
 .eyebrow {
@@ -555,10 +567,23 @@ textarea {
 
 .work-item-card {
   cursor: grab;
+  position: relative;
 }
 
 .work-item-card.is-dragging {
   opacity: 0.56;
+}
+
+.work-item-card.drag-over::before {
+  content: "";
+  position: absolute;
+  top: -6px;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: var(--dti-blue);
+  border-radius: 2px;
+  pointer-events: none;
 }
 
 .work-item-card.is-new-item {
@@ -577,6 +602,7 @@ textarea {
 .work-item-heading h3 {
   margin: 0;
   font-size: 1rem;
+  font-weight: 400;
   line-height: 1.3;
 }
 
@@ -602,20 +628,34 @@ textarea {
   gap: 8px;
 }
 
-.item-source-link {
+.item-actions {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.item-action-button {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
+  border: 0;
   border-radius: 999px;
-  padding: 6px 10px;
+  padding: 6px;
   background: rgba(14, 45, 73, 0.08);
   color: var(--dti-black);
   text-decoration: none;
-  font-size: 0.82rem;
-  white-space: nowrap;
+  cursor: pointer;
 }
 
-.item-source-link:hover {
+.item-action-button:hover {
   background: rgba(14, 45, 73, 0.16);
+}
+
+.action-icon {
+  width: 16px;
+  height: 16px;
+  display: block;
 }
 
 .new-pill {
@@ -806,7 +846,7 @@ textarea {
     margin-top: 12px;
   }
 
-  .item-source-link {
+  .item-actions {
     margin-top: 14px;
   }
 }


### PR DESCRIPTION
Closes #17

## Changes

### Bug fixes
- **Logout redirect** (`Program.cs`): `POST /api/auth/logout` now returns `Results.Redirect("/login")` instead of `Results.Ok(...)`, so the browser navigates to the login page after sign-out rather than rendering raw JSON
- **Drag-drop reorder** (`DashboardPage.razor`): Changed `@ondragover` → `@ondragenter` for `_dragOverItemId` tracking. `@ondragover` fires ~20×/sec and each call caused a Blazor Server SignalR round-trip that flooded the circuit and blocked `@ondrop` from processing

### Features
- **Move to Top button** (`DashboardPage.razor`): Arrow-to-top SVG icon button on each work item card; `MoveToTop()` does an in-place reorder (no server re-fetch) using the extracted `SaveOrderAsync()` helper shared with drag-drop
- **Gravatar avatar** (`NavBar.razor`): When no `picture` claim is present (e.g. Microsoft OAuth), computes `https://www.gravatar.com/avatar/{md5(email)}?s=68&d=mp` — falls back to generic silhouette, then initial-letter avatar
- **Visual drag-drop indicator** (`DashboardPage.razor`, `app.css`): `.drag-over::before` — 3px blue (`var(--dti-blue)`) bar at the top edge of the hovered card

### Polish
- **SVG icons** (`DashboardPage.razor`, `NavBar.razor`): Replaced text labels `Open in source` and `Sign out` with inline SVGs + `title` tooltip attributes; no external icon library added
- **Un-bold titles** (`app.css`): Added `font-weight: 400` to `.work-item-heading h3`
- **Sign-out icon button** (`app.css`, `NavBar.razor`): Restyled as icon-only button matching the navbar's light-on-dark colour scheme

## Verification

```
dotnet build PriorityHub.sln  ✅ succeeded
dotnet test PriorityHub.sln   ✅ 208 tests passed
```