### PR TITLE
fix(#37): differentiate Azure DevOps 404 from auth errors in error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Priority Hub adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 - `DashboardPage` and `SettingsPage` now inject `IConfigStore` instead of the concrete `LocalConfigStore`, resolving the `InvalidOperationException` at runtime when only the interface is registered in DI.
+- Azure DevOps connector now retries with configured PAT when Microsoft bearer token yields HTML sign-in/auth failures, avoiding false PAT guidance when a valid PAT is already provided.
+- Microsoft OAuth refresh-token exchange now requests Azure DevOps token using `https://app.vssps.visualstudio.com/user_impersonation` with GUID-scope fallback, reducing invalid Azure DevOps bearer token responses for Microsoft sign-in users.
 
 ### Changed
 - `LocalConfigStore` now implements `IConfigStore`.

--- a/backend/PriorityHub.Api.Tests/Connectors/ConnectorHttpTests.cs
+++ b/backend/PriorityHub.Api.Tests/Connectors/ConnectorHttpTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
 using PriorityHub.Api.Models;
 using PriorityHub.Api.Services.Connectors;
 
@@ -46,7 +47,7 @@ public sealed class ConnectorHttpTests
         }
         """);
 
-        var connector = new AzureDevOpsConnector(ClientWith(wiqlResponse, batchResponse));
+        var connector = new AzureDevOpsConnector(ClientWith(wiqlResponse, batchResponse), NullLogger<AzureDevOpsConnector>.Instance);
         var config = ConnectionJson(new { id = "x", name = "Test", organization = "myorg", project = "myproj", personalAccessToken = "pat", wiql = "SELECT [System.Id] FROM WorkItems", enabled = true });
 
         var result = await connector.FetchConnectionAsync(config, null, CancellationToken.None);
@@ -63,7 +64,7 @@ public sealed class ConnectorHttpTests
     {
         var wiqlResponse = OkJson("""{"workItems":[]}""");
 
-        var connector = new AzureDevOpsConnector(ClientWith(wiqlResponse));
+        var connector = new AzureDevOpsConnector(ClientWith(wiqlResponse), NullLogger<AzureDevOpsConnector>.Instance);
         var config = ConnectionJson(new { id = "x", name = "Test", organization = "myorg", project = "myproj", personalAccessToken = "pat", wiql = "SELECT [System.Id] FROM WorkItems WHERE [State] = 'Never'", enabled = true });
 
         var result = await connector.FetchConnectionAsync(config, null, CancellationToken.None);
@@ -77,7 +78,7 @@ public sealed class ConnectorHttpTests
     [Fact]
     public async Task AzureDevOps_UnauthorizedResponse_ReturnsNeedsAuth()
     {
-        var connector = new AzureDevOpsConnector(ClientWith(Unauthorized()));
+        var connector = new AzureDevOpsConnector(ClientWith(Unauthorized()), NullLogger<AzureDevOpsConnector>.Instance);
         var config = ConnectionJson(new { id = "x", name = "Test", organization = "myorg", project = "myproj", personalAccessToken = "bad-pat", wiql = "SELECT [System.Id] FROM WorkItems", enabled = true });
 
         var result = await connector.FetchConnectionAsync(config, null, CancellationToken.None);
@@ -90,7 +91,7 @@ public sealed class ConnectorHttpTests
     [Fact]
     public async Task AzureDevOps_MissingToken_ReturnsNeedsAuthWithoutHttpCall()
     {
-        var connector = new AzureDevOpsConnector(new HttpClient(new NeverCalledHttpMessageHandler()));
+        var connector = new AzureDevOpsConnector(new HttpClient(new NeverCalledHttpMessageHandler()), NullLogger<AzureDevOpsConnector>.Instance);
         var config = ConnectionJson(new { id = "x", name = "Test", organization = "myorg", project = "myproj", personalAccessToken = "", wiql = "SELECT [System.Id] FROM WorkItems", enabled = true });
 
         var result = await connector.FetchConnectionAsync(config, null, CancellationToken.None);
@@ -107,7 +108,7 @@ public sealed class ConnectorHttpTests
             Content = new StringContent("<html><body>Sign in to your account</body></html>", Encoding.UTF8, "text/html")
         };
 
-        var connector = new AzureDevOpsConnector(ClientWith(htmlResponse));
+        var connector = new AzureDevOpsConnector(ClientWith(htmlResponse), NullLogger<AzureDevOpsConnector>.Instance);
         var config = ConnectionJson(new { id = "x", name = "Test", organization = "myorg", project = "myproj", personalAccessToken = "expired-token", wiql = "SELECT [System.Id] FROM WorkItems", enabled = true });
 
         var result = await connector.FetchConnectionAsync(config, null, CancellationToken.None);
@@ -115,8 +116,28 @@ public sealed class ConnectorHttpTests
         Assert.Single(result.BoardConnections);
         Assert.Equal("needs-auth", result.BoardConnections[0].SyncStatus);
         Assert.Contains(result.Issues, issue =>
-            issue.Message.Contains("HTML") &&
-            issue.Message.Contains("sign-in", StringComparison.OrdinalIgnoreCase));
+            issue.Message.Contains("sign-in", StringComparison.OrdinalIgnoreCase) ||
+            issue.Message.Contains("not valid", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task AzureDevOps_404NotFound_ReportsOrgProjectError()
+    {
+        var htmlResponse = new HttpResponseMessage(HttpStatusCode.NotFound)
+        {
+            Content = new StringContent("<html><body>The resource cannot be found.</body></html>", Encoding.UTF8, "text/html")
+        };
+
+        var connector = new AzureDevOpsConnector(ClientWith(htmlResponse), NullLogger<AzureDevOpsConnector>.Instance);
+        var config = ConnectionJson(new { id = "x", name = "Test", organization = "badorg", project = "badproj", personalAccessToken = "", wiql = "SELECT [System.Id] FROM WorkItems", enabled = true });
+
+        var result = await connector.FetchConnectionAsync(config, "valid-bearer", CancellationToken.None);
+
+        Assert.Single(result.BoardConnections);
+        Assert.Equal("needs-auth", result.BoardConnections[0].SyncStatus);
+        Assert.Contains(result.Issues, issue =>
+            issue.Message.Contains("404", StringComparison.OrdinalIgnoreCase) &&
+            issue.Message.Contains("organization", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]
@@ -126,7 +147,7 @@ public sealed class ConnectorHttpTests
         var wiqlResponse = OkJson("""{"workItems":[]}""");
         var handler = new CapturingHttpMessageHandler(wiqlResponse, r => capturedAuth = r.Headers.Authorization);
 
-        var connector = new AzureDevOpsConnector(new HttpClient(handler));
+        var connector = new AzureDevOpsConnector(new HttpClient(handler), NullLogger<AzureDevOpsConnector>.Instance);
         var config = ConnectionJson(new { id = "x", name = "Test", organization = "myorg", project = "myproj", personalAccessToken = "my-pat", wiql = "SELECT [System.Id] FROM WorkItems", enabled = true });
 
         await connector.FetchConnectionAsync(config, "oauth-bearer-token", CancellationToken.None);
@@ -143,13 +164,47 @@ public sealed class ConnectorHttpTests
         var wiqlResponse = OkJson("""{"workItems":[]}""");
         var handler = new CapturingHttpMessageHandler(wiqlResponse, r => capturedAuth = r.Headers.Authorization);
 
-        var connector = new AzureDevOpsConnector(new HttpClient(handler));
+        var connector = new AzureDevOpsConnector(new HttpClient(handler), NullLogger<AzureDevOpsConnector>.Instance);
         var config = ConnectionJson(new { id = "x", name = "Test", organization = "myorg", project = "myproj", personalAccessToken = "my-pat", wiql = "SELECT [System.Id] FROM WorkItems", enabled = true });
 
         await connector.FetchConnectionAsync(config, null, CancellationToken.None);
 
         Assert.NotNull(capturedAuth);
         Assert.Equal("Basic", capturedAuth!.Scheme);
+    }
+
+    [Fact]
+    public async Task AzureDevOps_WhenBearerTokenInvalid_FallsBackToPat()
+    {
+        var htmlAuthFailure = new HttpResponseMessage(HttpStatusCode.Unauthorized)
+        {
+            Content = new StringContent("<html><body>Sign in</body></html>", Encoding.UTF8, "text/html")
+        };
+
+        var wiqlSuccess = OkJson("""{"workItems":[]}""");
+        var capturedSchemes = new List<string>();
+        var handler = new CapturingQueuedHttpMessageHandler(
+            new Queue<HttpResponseMessage>([htmlAuthFailure, wiqlSuccess]),
+            request => capturedSchemes.Add(request.Headers.Authorization?.Scheme ?? string.Empty));
+
+        var connector = new AzureDevOpsConnector(new HttpClient(handler), NullLogger<AzureDevOpsConnector>.Instance);
+        var config = ConnectionJson(new
+        {
+            id = "x",
+            name = "Test",
+            organization = "myorg",
+            project = "myproj",
+            personalAccessToken = "my-pat",
+            wiql = "SELECT [System.Id] FROM WorkItems",
+            enabled = true
+        });
+
+        var result = await connector.FetchConnectionAsync(config, "invalid-oauth-token", CancellationToken.None);
+
+        Assert.Equal(["Bearer", "Basic"], capturedSchemes);
+        Assert.Single(result.BoardConnections);
+        Assert.Equal("connected", result.BoardConnections[0].SyncStatus);
+        Assert.Empty(result.Issues);
     }
 
     // ── GitHub ───────────────────────────────────────────────────────────────
@@ -332,5 +387,20 @@ internal sealed class CapturingHttpMessageHandler(HttpResponseMessage response, 
     {
         onRequest(request);
         return Task.FromResult(response);
+    }
+}
+
+internal sealed class CapturingQueuedHttpMessageHandler(Queue<HttpResponseMessage> responses, Action<HttpRequestMessage> onRequest) : HttpMessageHandler
+{
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        onRequest(request);
+
+        if (responses.Count == 0)
+        {
+            throw new InvalidOperationException("No more queued HTTP responses.");
+        }
+
+        return Task.FromResult(responses.Dequeue());
     }
 }

--- a/backend/PriorityHub.Api.Tests/OauthTokenServiceTests.cs
+++ b/backend/PriorityHub.Api.Tests/OauthTokenServiceTests.cs
@@ -133,6 +133,35 @@ public sealed class OauthTokenServiceTests
         Assert.Null(authService.LastSignInProperties);
     }
 
+    [Fact]
+    public async Task MicrosoftProvider_WhenPrimaryAzureDevOpsScopeFails_UsesFallbackScope()
+    {
+        var configuration = BuildConfiguration();
+        var httpClient = new HttpClient(new QueueMessageHandler(new Queue<HttpResponseMessage>([
+            JsonResponse("""
+            {
+                "access_token": "graph-new-access",
+                "refresh_token": "graph-new-refresh",
+                "expires_in": 3600
+            }
+            """),
+            ErrorResponse(HttpStatusCode.BadRequest, """{"error":"invalid_scope"}"""),
+            JsonResponse("""{"access_token":"ado-access"}""")
+        ])));
+
+        var tokenService = new OauthTokenService(configuration, NullLogger<OauthTokenService>.Instance, new StaticHttpClientFactory(httpClient));
+        var httpContext = CreateHttpContext(
+            provider: "microsoft",
+            accessToken: "stale-access",
+            refreshToken: "stale-refresh",
+            out _);
+
+        var tokens = await tokenService.GetTokensByProviderAsync(httpContext, CancellationToken.None);
+
+        Assert.Equal("graph-new-access", tokens["microsoft-tasks"]);
+        Assert.Equal("ado-access", tokens["azure-devops"]);
+    }
+
     private static IConfiguration BuildConfiguration() =>
         new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
         {

--- a/backend/PriorityHub.Api/Services/Connectors/AzureDevOpsConnector.cs
+++ b/backend/PriorityHub.Api/Services/Connectors/AzureDevOpsConnector.cs
@@ -2,11 +2,12 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
+using Microsoft.Extensions.Logging;
 using PriorityHub.Api.Models;
 
 namespace PriorityHub.Api.Services.Connectors;
 
-public sealed class AzureDevOpsConnector(HttpClient httpClient) : IConnector
+public sealed class AzureDevOpsConnector(HttpClient httpClient, ILogger<AzureDevOpsConnector> logger) : IConnector
 {
     private const int WorkItemBatchSize = 100;
     private static readonly string[] RequestedFields =
@@ -66,6 +67,57 @@ public sealed class AzureDevOpsConnector(HttpClient httpClient) : IConnector
 
     public async Task<ConnectorResult> FetchConnectionAsync(AzureDevOpsConnection connection, string? bearerToken, CancellationToken cancellationToken)
     {
+        logger.LogDebug(
+            "ADO [{ConnectionId}] auth inputs: bearerToken={HasBearer}, PAT={HasPat}",
+            connection.Id,
+            !string.IsNullOrWhiteSpace(bearerToken),
+            !string.IsNullOrWhiteSpace(connection.PersonalAccessToken));
+
+        try
+        {
+            var authHeader = BuildAuthorizationHeader(connection, bearerToken);
+            logger.LogDebug(
+                "ADO [{ConnectionId}] using {Scheme} for initial request.",
+                connection.Id, authHeader.Scheme);
+
+            return await FetchConnectionInternalAsync(connection, authHeader, cancellationToken);
+        }
+        catch (Exception exception)
+        {
+            var canRetryWithPat =
+                !string.IsNullOrWhiteSpace(bearerToken) &&
+                !string.IsNullOrWhiteSpace(connection.PersonalAccessToken);
+            var isBearerFailure = IsBearerTokenAuthFailure(exception);
+
+            logger.LogWarning(
+                exception,
+                "ADO [{ConnectionId}] initial request failed. canRetryWithPat={CanRetry}, isBearerAuthFailure={IsBearerFailure}",
+                connection.Id, canRetryWithPat, isBearerFailure);
+
+            if (canRetryWithPat && isBearerFailure)
+            {
+                try
+                {
+                    logger.LogDebug("ADO [{ConnectionId}] retrying with PAT fallback.", connection.Id);
+                    var fallbackHeader = BuildPatAuthorizationHeader(connection);
+                    return await FetchConnectionInternalAsync(connection, fallbackHeader, cancellationToken);
+                }
+                catch (Exception fallbackException)
+                {
+                    logger.LogWarning(fallbackException, "ADO [{ConnectionId}] PAT fallback also failed.", connection.Id);
+                    return CreateFailedResult(connection, fallbackException.Message);
+                }
+            }
+
+            return CreateFailedResult(connection, exception.Message);
+        }
+    }
+
+    private async Task<ConnectorResult> FetchConnectionInternalAsync(
+        AzureDevOpsConnection connection,
+        AuthenticationHeaderValue authHeader,
+        CancellationToken cancellationToken)
+    {
         var result = new ConnectorResult();
         var boardConnection = new BoardConnection
         {
@@ -79,70 +131,53 @@ public sealed class AzureDevOpsConnector(HttpClient httpClient) : IConnector
             LastSyncMinutesAgo = 0
         };
 
-        try
+        using var wiqlRequest = new HttpRequestMessage(HttpMethod.Post, BuildWiqlUrl(connection))
         {
-            var authHeader = BuildAuthorizationHeader(connection, bearerToken);
-            using var wiqlRequest = new HttpRequestMessage(HttpMethod.Post, BuildWiqlUrl(connection))
-            {
-                Content = JsonContent.Create(new { query = connection.Wiql })
-            };
-            wiqlRequest.Headers.Authorization = authHeader;
+            Content = JsonContent.Create(new { query = connection.Wiql })
+        };
+        wiqlRequest.Headers.Authorization = authHeader;
 
-            using var wiqlResponse = await httpClient.SendAsync(wiqlRequest, cancellationToken);
-            using var wiqlDocument = await ReadJsonResponseAsync(wiqlResponse, "Azure DevOps WIQL request failed", cancellationToken);
-            var ids = wiqlDocument.RootElement.TryGetProperty("workItems", out var workItemsElement)
-                ? workItemsElement.EnumerateArray().Select(item => item.GetProperty("id").GetInt32()).ToArray()
-                : [];
+        using var wiqlResponse = await httpClient.SendAsync(wiqlRequest, cancellationToken);
+        using var wiqlDocument = await ReadJsonResponseAsync(wiqlResponse, "Azure DevOps WIQL request failed", cancellationToken);
+        var ids = wiqlDocument.RootElement.TryGetProperty("workItems", out var workItemsElement)
+            ? workItemsElement.EnumerateArray().Select(item => item.GetProperty("id").GetInt32()).ToArray()
+            : [];
 
-            if (ids.Length == 0)
-            {
-                boardConnection.FetchedItemCount = 0;
-                result.BoardConnections.Add(boardConnection);
-                return result;
-            }
-
-            foreach (var item in await FetchWorkItemsAsync(connection, authHeader, ids, cancellationToken))
-            {
-                var workItemId = item.GetProperty("id").GetInt32();
-                var fields = item.GetProperty("fields");
-                result.WorkItems.Add(new WorkItem
-                {
-                    Id = $"ADO-{workItemId}",
-                    Provider = "azure-devops",
-                    BoardId = connection.Id,
-                    SourceUrl = BuildWorkItemUrl(connection, workItemId),
-                    Title = ReadString(fields, "System.Title") ?? "Untitled work item",
-                    Status = MapStatus(ReadString(fields, "System.State")),
-                    Assignee = ReadNestedString(fields, "System.AssignedTo", "displayName") ?? string.Empty,
-                    Effort = ReadInt(fields, "Microsoft.VSTS.Scheduling.StoryPoints", 3),
-                    Impact = Math.Clamp(11 - ReadInt(fields, "Microsoft.VSTS.Common.Priority", 5), 1, 10),
-                    Urgency = Math.Clamp(11 - ReadInt(fields, "Microsoft.VSTS.Common.Severity", 5), 1, 10),
-                    Confidence = 7,
-                    AgeDays = DaysSince(ReadString(fields, "System.ChangedDate") ?? ReadString(fields, "System.CreatedDate")),
-                    BlockerCount = item.TryGetProperty("relations", out var relationsElement)
-                        ? relationsElement.EnumerateArray().Count(relation => relation.TryGetProperty("rel", out var rel) && rel.GetString()?.Contains("dependency", StringComparison.OrdinalIgnoreCase) == true)
-                        : 0,
-                    DueInDays = DueInDays(ReadString(fields, "Microsoft.VSTS.Scheduling.TargetDate")),
-                    Tags = ParseTags(ReadString(fields, "System.Tags"))
-                });
-            }
-
-            boardConnection.FetchedItemCount = result.WorkItems.Count;
+        if (ids.Length == 0)
+        {
+            boardConnection.FetchedItemCount = 0;
             result.BoardConnections.Add(boardConnection);
+            return result;
         }
-        catch (Exception exception)
+
+        foreach (var item in await FetchWorkItemsAsync(connection, authHeader, ids, cancellationToken))
         {
-            boardConnection.SyncStatus = "needs-auth";
-            boardConnection.LastSyncMinutesAgo = 999;
-            result.BoardConnections.Add(boardConnection);
-            result.Issues.Add(new ProviderIssue
+            var workItemId = item.GetProperty("id").GetInt32();
+            var fields = item.GetProperty("fields");
+            result.WorkItems.Add(new WorkItem
             {
+                Id = $"ADO-{workItemId}",
                 Provider = "azure-devops",
-                ConnectionId = connection.Id,
-                Message = exception.Message
+                BoardId = connection.Id,
+                SourceUrl = BuildWorkItemUrl(connection, workItemId),
+                Title = ReadString(fields, "System.Title") ?? "Untitled work item",
+                Status = MapStatus(ReadString(fields, "System.State")),
+                Assignee = ReadNestedString(fields, "System.AssignedTo", "displayName") ?? string.Empty,
+                Effort = ReadInt(fields, "Microsoft.VSTS.Scheduling.StoryPoints", 3),
+                Impact = Math.Clamp(11 - ReadInt(fields, "Microsoft.VSTS.Common.Priority", 5), 1, 10),
+                Urgency = Math.Clamp(11 - ReadInt(fields, "Microsoft.VSTS.Common.Severity", 5), 1, 10),
+                Confidence = 7,
+                AgeDays = DaysSince(ReadString(fields, "System.ChangedDate") ?? ReadString(fields, "System.CreatedDate")),
+                BlockerCount = item.TryGetProperty("relations", out var relationsElement)
+                    ? relationsElement.EnumerateArray().Count(relation => relation.TryGetProperty("rel", out var rel) && rel.GetString()?.Contains("dependency", StringComparison.OrdinalIgnoreCase) == true)
+                    : 0,
+                DueInDays = DueInDays(ReadString(fields, "Microsoft.VSTS.Scheduling.TargetDate")),
+                Tags = ParseTags(ReadString(fields, "System.Tags"))
             });
         }
 
+        boardConnection.FetchedItemCount = result.WorkItems.Count;
+        result.BoardConnections.Add(boardConnection);
         return result;
     }
 
@@ -207,6 +242,53 @@ public sealed class AzureDevOpsConnector(HttpClient httpClient) : IConnector
         }
 
         throw new InvalidOperationException("Azure DevOps authentication required. Sign in with Microsoft to grant access, or add a Personal Access Token for this connection.");
+    }
+
+    private static AuthenticationHeaderValue BuildPatAuthorizationHeader(AzureDevOpsConnection connection)
+    {
+        var encodedToken = Convert.ToBase64String(Encoding.UTF8.GetBytes($":{connection.PersonalAccessToken}"));
+        return new AuthenticationHeaderValue("Basic", encodedToken);
+    }
+
+    private static bool IsBearerTokenAuthFailure(Exception exception)
+    {
+        var message = exception.Message;
+
+        // A 404 means the org/project URL is wrong, not an auth failure.
+        if (message.Contains("returned 404", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return message.Contains("returned HTML instead of JSON", StringComparison.OrdinalIgnoreCase) ||
+            message.Contains("sign-in token is not valid", StringComparison.OrdinalIgnoreCase) ||
+            message.Contains("unauthorized", StringComparison.OrdinalIgnoreCase) ||
+            message.Contains("TF400813", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static ConnectorResult CreateFailedResult(AzureDevOpsConnection connection, string message)
+    {
+        var boardConnection = new BoardConnection
+        {
+            Id = connection.Id,
+            Provider = "azure-devops",
+            WorkspaceName = connection.Organization,
+            BoardName = connection.Name,
+            ProjectName = connection.Project,
+            Owner = string.Empty,
+            SyncStatus = "needs-auth",
+            LastSyncMinutesAgo = 999
+        };
+
+        var result = new ConnectorResult();
+        result.BoardConnections.Add(boardConnection);
+        result.Issues.Add(new ProviderIssue
+        {
+            Provider = "azure-devops",
+            ConnectionId = connection.Id,
+            Message = message
+        });
+        return result;
     }
 
     internal static string MapStatus(string? value)
@@ -295,7 +377,17 @@ public sealed class AzureDevOpsConnector(HttpClient httpClient) : IConnector
         var trimmed = (body ?? string.Empty).TrimStart();
         if (trimmed.StartsWith("<", StringComparison.Ordinal))
         {
-            return $"{prefix}: Azure DevOps returned HTML instead of JSON. The sign-in token is not valid for Azure DevOps. Re-sign in with Microsoft to refresh access, or add a Personal Access Token for this connection.";
+            if (statusCode == HttpStatusCode.NotFound)
+            {
+                return $"{prefix}: Azure DevOps returned 404 Not Found. Verify the organization and project names are correct (URL: dev.azure.com/{{organization}}/{{project}}).";
+            }
+
+            if (statusCode == HttpStatusCode.Unauthorized || statusCode == HttpStatusCode.Forbidden)
+            {
+                return $"{prefix}: Azure DevOps returned {(int)statusCode}. The sign-in token is not valid for Azure DevOps. Re-sign in with Microsoft to refresh access, or add a Personal Access Token for this connection.";
+            }
+
+            return $"{prefix}: Azure DevOps returned HTML instead of JSON (HTTP {(int)statusCode}). The sign-in token may not be valid for Azure DevOps. Re-sign in with Microsoft to refresh access, or add a Personal Access Token for this connection.";
         }
 
         var snippet = string.IsNullOrWhiteSpace(body)

--- a/backend/PriorityHub.Api/Services/OauthTokenService.cs
+++ b/backend/PriorityHub.Api/Services/OauthTokenService.cs
@@ -13,7 +13,11 @@ namespace PriorityHub.Api.Services;
 /// </summary>
 public sealed class OauthTokenService(IConfiguration configuration, ILogger<OauthTokenService> logger, IHttpClientFactory httpClientFactory)
 {
-    private const string AzureDevOpsScope = "499b84ac-1321-427f-aa17-267ca6975798/user_impersonation";
+    private static readonly string[] AzureDevOpsScopes =
+    [
+        "https://app.vssps.visualstudio.com/user_impersonation",
+        "499b84ac-1321-427f-aa17-267ca6975798/user_impersonation"
+    ];
     private const string MicrosoftGraphScope = "User.Read Tasks.Read Mail.Read offline_access";
 
     /// <summary>
@@ -59,19 +63,19 @@ public sealed class OauthTokenService(IConfiguration configuration, ILogger<Oaut
             tokens["microsoft-tasks"] = effectiveMicrosoftAccessToken;
             tokens["outlook-flagged-mail"] = effectiveMicrosoftAccessToken;
 
-            var azureDevOpsAccessToken = await RequestAccessTokenFromRefreshTokenAsync(
+            var azureDevOpsAccessToken = await RequestAzureDevOpsTokenAsync(
                 microsoftSection,
                 effectiveRefreshToken,
-                AzureDevOpsScope,
                 cancellationToken);
 
             if (!string.IsNullOrWhiteSpace(azureDevOpsAccessToken?.AccessToken))
             {
+                    logger.LogDebug("Azure DevOps OAuth token obtained successfully (length={Length}).", azureDevOpsAccessToken.AccessToken.Length);
                 tokens["azure-devops"] = azureDevOpsAccessToken.AccessToken;
             }
             else
             {
-                logger.LogWarning("Failed to exchange refresh token for Azure DevOps access token. Azure DevOps connections will require a PAT.");
+                logger.LogWarning("Failed to exchange refresh token for Azure DevOps access token. Azure DevOps connections will require a PAT. refreshToken present={HasRefresh}", !string.IsNullOrWhiteSpace(effectiveRefreshToken));
             }
         }
 
@@ -81,6 +85,36 @@ public sealed class OauthTokenService(IConfiguration configuration, ILogger<Oaut
         }
 
         return tokens;
+    }
+
+    private async Task<TokenExchangeResult?> RequestAzureDevOpsTokenAsync(
+        IConfigurationSection microsoftSection,
+        string? refreshToken,
+        CancellationToken cancellationToken)
+    {
+        logger.LogDebug("Azure DevOps token exchange: refreshToken present={HasRefresh}", !string.IsNullOrWhiteSpace(refreshToken));
+
+        foreach (var scope in AzureDevOpsScopes)
+        {
+            logger.LogDebug("Azure DevOps token exchange: trying scope {Scope}", scope);
+
+            var result = await RequestAccessTokenFromRefreshTokenAsync(
+                microsoftSection,
+                refreshToken,
+                scope,
+                cancellationToken);
+
+            if (!string.IsNullOrWhiteSpace(result?.AccessToken))
+            {
+                logger.LogDebug("Azure DevOps token exchange: scope {Scope} succeeded, token length={Length}", scope, result.AccessToken.Length);
+                return result;
+            }
+
+            logger.LogDebug("Azure DevOps token exchange: scope {Scope} returned no token.", scope);
+        }
+
+        logger.LogWarning("Azure DevOps token exchange: all scopes exhausted, no token obtained.");
+        return null;
     }
 
     private async Task PersistRefreshedTokensAsync(


### PR DESCRIPTION
## Summary

Fixes #37

When an Azure DevOps connection has an incorrect organization or project name, the connector receives HTTP 404 from `dev.azure.com`. Previously, `FormatAzureError` treated **any** HTML response as an authentication failure, producing the misleading message: *"The sign-in token is not valid for Azure DevOps."*

Diagnostic investigation confirmed the OAuth token was valid (correct audience and scope) — the actual problem was a wrong org/project URL returning 404.

## Changes

### Error message differentiation (`AzureDevOpsConnector.cs`)
- **`FormatAzureError`** now checks HTTP status code:
  - **404** → "Verify the organization and project names are correct"
  - **401/403** → "The sign-in token is not valid"
  - **Other HTML** → generic message with status code
- **`IsBearerTokenAuthFailure`** excludes 404 from auth failure detection to prevent unnecessary PAT fallback

### Bearer-to-PAT fallback
- When bearer token auth fails (401/403) and a PAT is configured, the connector retries with Basic auth

### Dual-scope Azure DevOps token exchange (`OauthTokenService.cs`)
- Token exchange tries URL-form scope first (`https://app.vssps.visualstudio.com/user_impersonation`), then GUID-form fallback (`499b84ac-.../user_impersonation`)
- Added structured debug logging via `ILogger`

### Tests
- **New**: `AzureDevOps_404NotFound_ReportsOrgProjectError`
- **New**: `AzureDevOps_WhenBearerTokenInvalid_FallsBackToPat`
- **New**: `MicrosoftProvider_WhenPrimaryAzureDevOpsScopeFails_UsesFallbackScope`
- **Updated**: existing HTML response test assertion

## Verification

- `dotnet build PriorityHub.sln` — 0 errors, 0 warnings
- All 122 tests pass (45 directly related tests pass)