### PR TITLE
test: skip PostgreSQL integration tests when Docker is not available

### DIFF
--- a/backend/PriorityHub.Api.Tests/PostgresConfigStoreIntegrationTests.cs
+++ b/backend/PriorityHub.Api.Tests/PostgresConfigStoreIntegrationTests.cs
@@ -44,7 +44,7 @@ public sealed class PostgresConfigStoreIntegrationTests : IAsyncLifetime
 
     // ── LoadAsync ────────────────────────────────────────────────────────────
 
-    [Fact]
+    [SkipIfNoDockerFact]
     public async Task LoadAsync_UnknownUser_ReturnsNormalizedEmptyConfig()
     {
         var store = CreateStore();
@@ -61,7 +61,7 @@ public sealed class PostgresConfigStoreIntegrationTests : IAsyncLifetime
 
     // ── SaveAsync / LoadAsync round-trip ─────────────────────────────────────
 
-    [Fact]
+    [SkipIfNoDockerFact]
     public async Task SaveAsync_ThenLoadAsync_ReturnsSameData()
     {
         var store = CreateStore();
@@ -86,7 +86,7 @@ public sealed class PostgresConfigStoreIntegrationTests : IAsyncLifetime
         Assert.Contains("ADO-1", loaded.Preferences.OrderedItemIds);
     }
 
-    [Fact]
+    [SkipIfNoDockerFact]
     public async Task SaveAsync_CalledTwice_OverwritesData()
     {
         var store = CreateStore();
@@ -110,7 +110,7 @@ public sealed class PostgresConfigStoreIntegrationTests : IAsyncLifetime
         Assert.Equal("Second Board", loaded.Trello[0].Name);
     }
 
-    [Fact]
+    [SkipIfNoDockerFact]
     public async Task SaveAsync_IncrementsVersion()
     {
         var store = CreateStore();
@@ -128,7 +128,7 @@ public sealed class PostgresConfigStoreIntegrationTests : IAsyncLifetime
         Assert.Equal(2, version);
     }
 
-    [Fact]
+    [SkipIfNoDockerFact]
     public async Task SaveAsync_IsolatesByUserId()
     {
         var store = CreateStore();
@@ -156,7 +156,7 @@ public sealed class PostgresConfigStoreIntegrationTests : IAsyncLifetime
 
     // ── SchemaManager ────────────────────────────────────────────────────────
 
-    [Fact]
+    [SkipIfNoDockerFact]
     public async Task SchemaManager_SecondApply_IsIdempotent()
     {
         var env = new TestHostEnvironment(Path.GetTempPath()) { EnvironmentName = "Development" };

--- a/backend/PriorityHub.Api.Tests/TestHelpers.cs
+++ b/backend/PriorityHub.Api.Tests/TestHelpers.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Testcontainers.PostgreSql;
 
 namespace PriorityHub.Api.Tests;
 
@@ -31,5 +32,37 @@ internal sealed class TestLogger<T> : ILogger<T>
     public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
     public bool IsEnabled(LogLevel logLevel) => false;
     public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter) { }
+}
+
+/// <summary>
+/// <see cref="FactAttribute"/> that skips the test when Docker is not available,
+/// rather than failing with an unhelpful ArgumentException.
+/// Docker availability is checked once per test session via a lazy static.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method)]
+internal sealed class SkipIfNoDockerFactAttribute : FactAttribute
+{
+    private static readonly Lazy<bool> DockerAvailable = new(static () =>
+    {
+        try
+        {
+            // Build() calls Validate() which throws ArgumentException when Docker is absent.
+            // We intentionally discard the result; the container is never started.
+            _ = new PostgreSqlBuilder().Build();
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+    });
+
+    public SkipIfNoDockerFactAttribute()
+    {
+        if (!DockerAvailable.Value)
+        {
+            Skip = "Docker is not available or not running. Start Docker Desktop to run integration tests.";
+        }
+    }
 }
 


### PR DESCRIPTION
## Summary

PostgreSQL integration tests were failing with an `ArgumentException` crash when Docker Desktop wasn't running, instead of skipping gracefully. This was caused by `PostgreSqlContainer` being built in a C# field initializer — `Build()` validates Docker availability at that point, before xUnit could apply any skip logic.

## Changes

### `TestHelpers.cs`
- Added `SkipIfNoDockerFactAttribute` — a custom `[Fact]` subclass that checks Docker availability once per test session using a `Lazy<bool>`. When Docker is unavailable, it sets `Skip` on the attribute so xUnit skips the test without instantiating the fixture class.

### `PostgresConfigStoreIntegrationTests.cs`
- Replaced all `[Fact]` attributes with `[SkipIfNoDockerFact]`.

## Before / After

| State | Before | After |
|---|---|---|
| Docker **running** | ✅ Tests pass | ✅ Tests pass |
| Docker **not running** | ❌ 6 tests crash (`ArgumentException`) | ⏭️ 6 tests skipped |

## Verification

```
dotnet test PriorityHub.sln
261 passed, 0 failed (6 PostgreSQL integration tests skipped — Docker not running)
```
