### PR TITLE
docs(#64): add end-user Quick Start guide

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,7 +29,8 @@ This file is the workspace-level quick guide for AI agents. Detailed coding rule
 
 ### Documentation
 - Keep `README.md` as the entry point for setup, usage, and links to `docs/`.
-- Keep detailed user documentation in `docs/` (features, configuration, processes, troubleshooting).
+- Keep `docs/quick-start.md` up to date whenever a feature is added or changed that affects setup steps, connector fields, dashboard behavior, or the getting-started workflow.
+- Keep detailed user documentation in `docs/` (quick start, features, configuration, processes, troubleshooting).
 - Keep plan files in `plans/` updated with progress and verification steps.
 
 ### Documentation Environment Setup

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,8 @@ Purpose: implement approved work safely and consistently in Priority Hub (Blazor
 
 ### Documentation Rules
 - Treat `README.md` as the canonical user setup and usage document.
-- Keep detailed user documentation in `docs/` organized by section: features, configuration, processes, troubleshooting.
+- Keep `docs/quick-start.md` up to date whenever a feature is added or changed that affects setup steps, connector fields, dashboard behavior, or the getting-started workflow.
+- Keep detailed user documentation in `docs/` organized by section: quick start, features, configuration, processes, troubleshooting.
 - Keep instructions task-based: prerequisites, steps, expected result, and troubleshooting.
 - Ensure all commands are copy-paste ready and tested in this repository.
 - Keep terminology consistent across README, plans, and UI labels.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Priority Hub adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - **Agent definitions normalized**: removed VS Code-specific fields (`tools`, `model`, `target`) from all `.github/agents/*.agent.md` files; normalized quote styles to single quotes and reordered frontmatter (`name` before `description`) to align with GitHub Copilot agent format standards.
 
 ### Added
+- **Quick Start guide**: new `docs/quick-start.md` walks end users through sign-in, connector setup, and dashboard usage, covering all six providers with example field values.
 - **Export download**: the "Download configuration" button now triggers a real browser file download (`priority-hub-config.json`) via JS interop instead of only updating the status message.
 - **Import connector configuration**: a new "Import connector configuration" card on the Import / Export tab lets users upload a previously exported JSON file (max 1 MB). Connections are merged with upsert logic: connections matched by `id` are updated; new `id`s are inserted; connections absent from the file are left unchanged. Preferences (manual ordering) are never overwritten.
 - **Import preview**: after selecting a file, a preview panel summarises how many connections will be added, updated, or unchanged, lists each affected connection by name and provider, and warns if masked secrets (`********`) are detected.

--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ Key references:
 
 Full user documentation is in [`docs/`](docs/):
 
+- [Quick Start](docs/quick-start.md) – sign in, add connectors, and start using the dashboard.
 - [Features](docs/features/README.md) – dashboard, priority ordering, and multi-connector model.
 - [Configuration](docs/configuration/README.md) – provider setup and credential management.
 - [Processes](docs/processes/README.md) – versioning, changelog, and contribution workflow.

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ This directory contains user-facing documentation for Priority Hub.
 
 | Section | Description |
 |---------|-------------|
+| [Quick Start](quick-start.md) | Sign in, add connectors, and start using the dashboard |
 | [Features](features/README.md) | How Priority Hub works and what it provides |
 | [Configuration](configuration/README.md) | Provider setup and credential management |
 | [Processes](processes/README.md) | Development workflow and contribution processes |

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,0 +1,144 @@
+# Quick Start
+
+Sign in, connect your work-item sources, and start triaging — all from the browser.
+
+> **For developers and administrators:** see the [project README](../README.md) for installation, build, and deployment instructions.
+
+## Step 1: Sign in
+
+Open Priority Hub in your browser and click a sign-in button (e.g., Microsoft or GitHub).
+You will be redirected to your provider's login screen and back to Priority Hub once authenticated.
+
+## Step 2: Add your first connector
+
+1. Click the **Settings** gear icon in the top navigation bar.
+2. Expand a provider section (e.g., Azure DevOps, Jira, GitHub Issues, Trello, Microsoft Tasks, or Outlook Flagged Mail).
+3. Click **Add connection**.
+4. Fill in the required fields. Each provider section includes a help panel — click it for field descriptions and tips.
+
+Below are the fields for each provider with example values.
+
+### Azure DevOps
+
+| Field | Required | Example value |
+|-------|----------|---------------|
+| Connection name | ✔ | `My Project` |
+| Organization | ✔ | `contoso` |
+| Project | ✔ | `Commerce Platform` |
+| Personal Access Token | | *(not needed when signed in with Microsoft)* |
+| WIQL query | ✔ | `Select [System.Id] From WorkItems Where [System.TeamProject] = @project And [System.State] <> 'Closed' And [System.AssignedTo] = @me Order By [System.ChangedDate] Desc` |
+
+If you use a PAT, it needs **Work Items (Read)** scope. [Create a PAT](https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate) · [WIQL syntax](https://learn.microsoft.com/en-us/azure/devops/boards/queries/wiql-syntax)
+
+### GitHub Issues
+
+| Field | Required | Example value |
+|-------|----------|---------------|
+| Connection name | ✔ | `My Repo Issues` |
+| Owner / organization | ✔ | `my-org` |
+| Repository | ✔ | `my-repo` |
+| Personal access token | | *(not needed when signed in with GitHub)* |
+| Issue query | | `is:open assignee:@me` |
+
+If you use a PAT, it needs **Issues (Read)** permission. [Create a PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) · [Search syntax](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests)
+
+### Jira
+
+| Field | Required | Example value |
+|-------|----------|---------------|
+| Connection name | ✔ | `Growth Board` |
+| Base URL | ✔ | `https://yourorg.atlassian.net` |
+| Email | ✔ | `you@example.com` |
+| API token | ✔ | *(from your Atlassian account)* |
+| JQL query | ✔ | `assignee = currentUser() AND statusCategory != Done ORDER BY updated DESC` |
+
+[Manage API tokens](https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/) · [JQL reference](https://support.atlassian.com/jira-software-cloud/docs/what-is-advanced-searching-in-jira-software/)
+
+### Trello
+
+| Field | Required | Example value |
+|-------|----------|---------------|
+| Connection name | ✔ | `Advisory Pipeline` |
+| Board ID | ✔ | `AbCd1234` *(the 8-character code in your board URL)* |
+| API key | ✔ | *(from Trello developer portal)* |
+| Token | ✔ | *(generated on the same page as the API key)* |
+
+[Get your API key and token](https://trello.com/app-key)
+
+### Microsoft Tasks
+
+| Field | Required | Example value |
+|-------|----------|---------------|
+| Connection name | ✔ | `My Tasks` |
+| Task list name | | *(leave blank for all lists)* |
+
+Requires Microsoft sign-in. No API token needed.
+
+### Outlook Flagged Mail
+
+| Field | Required | Example value |
+|-------|----------|---------------|
+| Connection name | ✔ | `Flagged Mail` |
+| Folder ID | | *(leave blank for all folders)* |
+| Max results | | `100` |
+
+Requires Microsoft sign-in. No API token needed.
+
+5. Click **Save**. The connector appears on the dashboard on the next refresh.
+
+> **Tip:** You can add multiple connections for the same provider (e.g., two Azure DevOps projects). All of them feed into the same priority view.
+
+## Step 3: Use the dashboard
+
+Navigate to **Dashboard**. Your work items from all connected sources appear in a single ranked list, grouped into three priority bands:
+
+| Band | Score | Meaning |
+|------|-------|---------|
+| **Critical** | 82–100 | Needs immediate attention |
+| **Focus** | 60–81 | Tackle in the current cycle |
+| **Maintain** | 0–59 | Keep moving or defer |
+
+### Reorder items
+
+Drag and drop any item to override the automatic score-based order. Your manual position is saved and persists across sessions.
+
+Items added since your last reorder are highlighted with a **New** badge so you can place them where they belong.
+
+### Filter the view
+
+Use the toolbar filters to narrow the list:
+
+- **Connectors** — show items from specific providers.
+- **Tags** — filter by label or tag.
+- **Blocked** — show all, blocked only, or not blocked.
+- **Target date** — all, has date, no date, overdue, or due within 7 days.
+
+### Understand the cards
+
+Each work item card shows:
+
+- **Title** and link to the original item in its source system.
+- **Provider icon** and connection name.
+- **Priority score** with the color-coded band.
+- **Status** normalized across providers (Planned, In Progress, Review, Blocked, Done).
+- **Blocked pill** (red) when the item is flagged as blocked in its source.
+- **Target date** with a countdown badge: red if overdue, amber if due within 7 days.
+
+## Step 4: Manage your configuration
+
+### Edit or remove a connector
+
+Go to **Settings**, expand the provider section, and edit the fields or click **Remove** (a confirmation dialog will appear before deletion).
+
+### Export and import
+
+Use the **Import / Export** tab in Settings to:
+
+- **Download** your full configuration as a JSON file for backup.
+- **Import** a previously exported file to restore or migrate connections.
+
+## What's next?
+
+- See [Features](features/README.md) for the full scoring formula, status mapping, and multi-connector details.
+- See [Configuration](configuration/README.md) for advanced query examples and the complete field reference.
+- Check [Troubleshooting](troubleshooting/README.md) if the dashboard is empty or a connector shows an error.


### PR DESCRIPTION
Closes #64

## Summary

Adds an end-user Quick Start guide and updates agent instructions to maintain it going forward.

## Changes

- **New:** `docs/quick-start.md` — 4-step guide for end users:
  1. Sign in via OAuth
  2. Add connectors (all 6 providers with field tables, example values, and external doc links)
  3. Use the dashboard (priority bands, drag-and-drop, filters, card anatomy)
  4. Manage configuration (edit/remove connectors, import/export)
- **Updated:** `docs/README.md` — Quick Start added as the first entry in the docs index
- **Updated:** `README.md` — Quick Start link added in the Documentation section
- **Updated:** `AGENTS.md` and `.github/copilot-instructions.md` — added maintenance rule: *"Keep `docs/quick-start.md` up to date whenever a feature is added or changed that affects setup steps, connector fields, dashboard behavior, or the getting-started workflow."*
- **Updated:** `CHANGELOG.md` — entry under `[Unreleased] > Added`

## Verification

- `dotnet build PriorityHub.sln` — passes
- `dotnet test PriorityHub.sln` — all 352 tests pass