### PR TITLE
fix(#72): span toggle row across hero-panel grid columns

### DIFF
--- a/backend/PriorityHub.Ui/wwwroot/app.css
+++ b/backend/PriorityHub.Ui/wwwroot/app.css
@@ -509,6 +509,10 @@ textarea {
   line-height: 1;
 }
 
+.hero-panel > .section-toggle-row {
+  grid-column: 1 / -1;
+}
+
 .hero-panel.is-collapsed {
   display: block;
   margin-bottom: 12px;


### PR DESCRIPTION
Closes #72

## Problem
Toggling Hide/Show overview on the dashboard broke `.hero-copy` and `.hero-metrics` into separate rows at viewports wider than 1100px.

## Cause
The `.section-toggle-row` button occupied the first column of the 2-column `.hero-panel` grid, pushing the subsequent children out of alignment.

## Fix
Added `grid-column: 1 / -1` to `.hero-panel > .section-toggle-row` so the toggle row spans both columns.

## Verification
- `dotnet build PriorityHub.sln` — passes
- `dotnet test PriorityHub.sln` — 413 tests pass