### PR TITLE
feat(#87): default ADO WIQL to include Assigned to Me filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Priority Hub adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed
+- **Default ADO WIQL includes "Assigned to Me"**: new Azure DevOps connectors now default to `[System.AssignedTo] = @me` in the WIQL query, matching the Jira connector's `assignee = currentUser()` behavior. Existing connectors are unaffected.
+
 ### Added
 - **First-run onboarding redirect**: when an authenticated user has no connectors configured, the dashboard automatically redirects to `/settings?onboarding=true` with a welcome toast guiding them to configure their first connector.
 - **Import auto-save and tab switch**: confirming a configuration import now automatically persists the imported settings and navigates to the Connectors tab with a success banner. On save failure, the user stays on the Import/Export tab with an error message.

--- a/backend/PriorityHub.Api/Models/ConfigModels.cs
+++ b/backend/PriorityHub.Api/Models/ConfigModels.cs
@@ -56,7 +56,7 @@ public sealed class AzureDevOpsConnection
     public string Project { get; set; } = string.Empty;
     [SensitiveField]
     public string PersonalAccessToken { get; set; } = string.Empty;
-    public string Wiql { get; set; } = "Select [System.Id] From WorkItems Where [System.TeamProject] = @project And [System.State] <> 'Closed' Order By [System.ChangedDate] Desc";
+    public string Wiql { get; set; } = "Select [System.Id] From WorkItems Where [System.AssignedTo] = @me And [System.TeamProject] = @project And [System.State] <> 'Closed' Order By [System.ChangedDate] Desc";
     public bool Enabled { get; set; } = true;
 }
 

--- a/backend/PriorityHub.Api/Services/Connectors/AzureDevOpsConnector.cs
+++ b/backend/PriorityHub.Api/Services/Connectors/AzureDevOpsConnector.cs
@@ -36,7 +36,7 @@ public sealed class AzureDevOpsConnector(HttpClient httpClient, ILogger<AzureDev
         new("project", "Project"),
         new("personalAccessToken", "PAT (optional with Microsoft sign-in)", "password", false),
         new("wiql", "WIQL", "textarea", true,
-            "Select [System.Id] From WorkItems Where [System.TeamProject] = @project And [System.State] <> 'Closed' Order By [System.ChangedDate] Desc"),
+            "Select [System.Id] From WorkItems Where [System.AssignedTo] = @me And [System.TeamProject] = @project And [System.State] <> 'Closed' Order By [System.ChangedDate] Desc"),
     ];
 
     public async Task<ConnectorResult> FetchConnectionAsync(JsonElement connectionConfig, string? oauthToken, CancellationToken cancellationToken)

--- a/config/providers.example.json
+++ b/config/providers.example.json
@@ -9,7 +9,7 @@
       "organization": "your-organization",
       "project": "Commerce Platform",
       "personalAccessToken": "replace-with-pat",
-      "wiql": "Select [System.Id] From WorkItems Where [System.TeamProject] = @project And [System.State] <> 'Closed' Order By [System.ChangedDate] Desc",
+      "wiql": "Select [System.Id] From WorkItems Where [System.AssignedTo] = @me And [System.TeamProject] = @project And [System.State] <> 'Closed' Order By [System.ChangedDate] Desc",
       "enabled": true
     },
     {
@@ -18,7 +18,7 @@
       "organization": "your-organization",
       "project": "Shared Services",
       "personalAccessToken": "replace-with-pat",
-      "wiql": "Select [System.Id] From WorkItems Where [System.TeamProject] = @project And [System.State] <> 'Closed' Order By [System.ChangedDate] Desc",
+      "wiql": "Select [System.Id] From WorkItems Where [System.AssignedTo] = @me And [System.TeamProject] = @project And [System.State] <> 'Closed' Order By [System.ChangedDate] Desc",
       "enabled": true
     }
   ],

--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -365,7 +365,7 @@ When a linked account is selected, its refresh token is exchanged for a Microsof
       "organization": "contoso",
       "project": "Commerce Platform",
       "personalAccessToken": "<your-pat>",
-      "wiql": "Select [System.Id] From WorkItems Where [System.TeamProject] = @project And [System.State] <> 'Closed' Order By [System.ChangedDate] Desc",
+      "wiql": "Select [System.Id] From WorkItems Where [System.AssignedTo] = @me And [System.TeamProject] = @project And [System.State] <> 'Closed' Order By [System.ChangedDate] Desc",
       "enabled": true
     }
   ],


### PR DESCRIPTION
## Summary

Default ADO WIQL queries to include `[System.AssignedTo] = @me`, so new Azure DevOps connectors only show items assigned to the current user. This matches the Jira connector's `assignee = currentUser()` default.

Existing connectors are unaffected — only the default for **new** connectors changes.

## Changes

- **ConfigModels.cs** — Updated `AzureDevOpsConnection.Wiql` default
- **AzureDevOpsConnector.cs** — Updated `ConfigFields` WIQL default
- **providers.example.json** — Updated example queries
- **docs/configuration/README.md** — Updated documentation examples
- **CHANGELOG.md** — Added entry under `[Unreleased]`

Closes #87
Spec: #83